### PR TITLE
fix: add write permissions for GitHub release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

This PR fixes the GitHub Actions release workflow that was failing with a 403 error when trying to create releases.

## Problem

The release workflow was failing at the "Create GitHub Release" step with:
```
⚠️ GitHub release failed with status: 403
```

## Solution

Added `permissions: contents: write` to the job configuration to grant the workflow permission to create releases.

## Test Plan

The fix will be tested when the next release tag is pushed after this PR is merged.

🤖 Generated with [Claude Code](https://claude.ai/code)