### PR TITLE
feat: Add standalone executable support (v0.2.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,56 @@ on:
       - 'v*'
 
 jobs:
+  build-executables:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            artifact_name: mcp-testing-sensei-linux
+          - os: windows-latest
+            artifact_name: mcp-testing-sensei-windows.exe
+          - os: macos-latest
+            artifact_name: mcp-testing-sensei-macos
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+
+      - name: Build executable
+        run: |
+          pyinstaller mcp_testing_sensei.spec
+
+      - name: Rename executable
+        shell: bash
+        run: |
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+            mv dist/mcp-testing-sensei.exe dist/${{ matrix.artifact_name }}
+          else
+            mv dist/mcp-testing-sensei dist/${{ matrix.artifact_name }}
+          fi
+
+      - name: Upload executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: dist/${{ matrix.artifact_name }}
+
   build-and-publish:
     runs-on: ubuntu-latest
+    needs: build-executables
     permissions:
       contents: write
     steps:
@@ -65,10 +113,16 @@ jobs:
           docker push $DOCKER_USERNAME/mcp-testing-sensei:${GITHUB_REF#refs/tags/}
           docker push $DOCKER_USERNAME/mcp-testing-sensei:latest
 
+      - name: Download executables
+        uses: actions/download-artifact@v4
+        with:
+          path: executables
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
             dist/*
             *.tgz
+            executables/*/*
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -20,9 +20,23 @@ This tool aims to promote the following unit testing principles:
 
 ## Installation
 
-### Option 1: Install from PyPI (Recommended)
+### Option 1: Standalone Executable (No Python Required)
 
-The easiest way to install MCP Testing Sensei is via pip:
+Download the pre-built executable for your platform from the [latest release](https://github.com/kourtni/mcp-testing-sensei/releases/latest):
+
+- **Linux**: `mcp-testing-sensei-linux`
+- **macOS**: `mcp-testing-sensei-macos`
+- **Windows**: `mcp-testing-sensei-windows.exe`
+
+Make the file executable (Linux/macOS):
+```bash
+chmod +x mcp-testing-sensei-linux
+./mcp-testing-sensei-linux
+```
+
+### Option 2: Install from PyPI
+
+If you have Python installed, you can use pip:
 
 ```bash
 pip install mcp-testing-sensei
@@ -30,7 +44,7 @@ pip install mcp-testing-sensei
 
 This installs the `mcp-testing-sensei` command globally.
 
-### Option 2: Install from npm
+### Option 3: Install from npm
 
 If you prefer using npm:
 
@@ -40,13 +54,13 @@ npm install -g @kourtni/mcp-testing-sensei
 
 Note: This still requires Python to be installed on your system.
 
-### Option 3: Using Docker
+### Option 4: Using Docker
 
 ```bash
 docker pull kourtni/mcp-testing-sensei
 ```
 
-### Option 4: Development Setup with Nix
+### Option 5: Development Setup with Nix
 
 For development or if you want to build from source:
 

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
         twine
         setuptools
         wheel
+        pyinstaller
       ]);
 
     in

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -8,7 +8,7 @@ import mcp.server.fastmcp
 import linter
 
 # Version of the package - keep in sync with pyproject.toml
-__version__ = '0.1.5'
+__version__ = '0.2.0'
 
 
 # Core testing principles

--- a/mcp_testing_sensei.spec
+++ b/mcp_testing_sensei.spec
@@ -1,0 +1,43 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+a = Analysis(
+    ['mcp_server.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=['mcp', 'mcp.server', 'mcp.server.models', 'mcp.types', 'typing_extensions'],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name='mcp-testing-sensei',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kourtni/mcp-testing-sensei",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "MCP server for testing standards",
   "bin": {
     "mcp-testing-sensei": "run.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mcp-testing-sensei"
-version = "0.1.5"
+version = "0.2.0"
 description = "An MCP server to enforce/guide agentic coding tools to use general unit testing standards."
 authors = ["Kourtni Marshall"]
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r', encoding='utf-8') as fh:
 
 setup(
     name='mcp-testing-sensei',
-    version='0.1.4',
+    version='0.2.0',
     author='Kourtni Marshall',
     description='An MCP server to enforce testing standards',
     long_description=long_description,


### PR DESCRIPTION
## Summary
- Adds PyInstaller support to create standalone executables that don't require Python
- Updates GitHub release workflow to automatically build executables for Linux, Windows, and macOS
- Makes standalone executables the primary installation method in documentation

## Changes
- Added PyInstaller to Nix development environment
- Created `mcp_testing_sensei.spec` configuration for building executables
- Updated `.github/workflows/release.yml` to build platform-specific executables
- Updated README to list standalone executables as the primary installation option
- Bumped version to 0.2.0 across all package files

## Test plan
- [x] Built and tested executable locally in Nix shell
- [x] Verified executable runs without Python dependency
- [ ] GitHub Actions will build executables on next release tag

This is a significant user experience improvement - users can now download and run the MCP server without having Python installed\!

🤖 Generated with [Claude Code](https://claude.ai/code)